### PR TITLE
Add Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+COPY clash-converter-api/requirements.txt ./clash-converter-api/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir -r clash-converter-api/requirements.txt
+COPY . .
+EXPOSE 5000
+CMD ["python", "clash-converter-api/src/main.py"]

--- a/README.md
+++ b/README.md
@@ -269,6 +269,24 @@ RULESET_URLS = {
 python tests/test_new_features.py
 ```
 
+## 🐳 Docker部署
+
+使用Docker可以快速运行后端API服务（已包含构建好的前端静态文件）。
+
+### 构建镜像
+
+```bash
+docker build -t clash-converter .
+```
+
+### 运行容器
+
+```bash
+docker run -d -p 5000:5000 clash-converter
+```
+
+启动后访问 `http://localhost:5000` 查看服务是否正常。
+
 ## 🤝 贡献指南
 
 欢迎提交Issue和Pull Request来改进这个项目：


### PR DESCRIPTION
## Summary
- add Dockerfile for API deployment
- document Docker usage in README

## Testing
- `python -m pytest -q` *(fails: cannot import name 'generate_proxy_groups')*

------
https://chatgpt.com/codex/tasks/task_e_684bac07ef7083209d001ac66bc8fb1e