### PR TITLE
Fix API URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ docker run -d -p 5000:5000 clash-converter
 
 启动后访问 `http://localhost:5000` 查看服务是否正常。
 
+### 配置前端 API 地址
+
+前端页面会从 `VITE_API_BASE_URL` 环境变量读取后端 API 地址，若未设置则默认
+请求当前域名下的 `/api` 路径。在开发模式下可指定该变量：
+
+```bash
+VITE_API_BASE_URL=http://localhost:5000/api pnpm dev
+```
+
 ## 🤝 贡献指南
 
 欢迎提交Issue和Pull Request来改进这个项目：

--- a/clash-converter-ionic/src/App.jsx
+++ b/clash-converter-ionic/src/App.jsx
@@ -1,7 +1,8 @@
 import { IonApp, IonHeader, IonToolbar, IonTitle, IonContent, IonItem, IonLabel, IonInput, IonList, IonCheckbox, IonButton, IonAlert, IonLoading } from '@ionic/react';
 import { useEffect, useState } from 'react';
 
-const API_BASE_URL = 'http://localhost:5000/api';
+// 通过环境变量 VITE_API_BASE_URL 指定后端地址，默认指向同源的 /api
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 function App() {
   const [subscriptionUrl, setSubscriptionUrl] = useState('');

--- a/clash-converter-web/src/App.jsx
+++ b/clash-converter-web/src/App.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 
-const API_BASE_URL = 'http://localhost:5000/api'
+// API 基础地址可通过环境变量 VITE_API_BASE_URL 配置
+// 默认为與當前網站同源的 `/api` 路徑
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 function App() {
   const [activeTab, setActiveTab] = useState('convert')


### PR DESCRIPTION
## Summary
- make frontend API base URL configurable via `VITE_API_BASE_URL`
- document API URL configuration in README

## Testing
- `pytest -q` *(fails: cannot import name 'generate_proxy_groups' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684cd7e484a88320a981d84232b68293